### PR TITLE
Guard for meshRef.current instead of isEuler

### DIFF
--- a/src/stories/Spinner.tsx
+++ b/src/stories/Spinner.tsx
@@ -6,7 +6,7 @@ const Spinner: React.FC = () => {
   const meshRef = useResource<THREE.Mesh>();
 
   useFrame(({ clock }) => {
-    if (meshRef.current.rotation.isEuler) {
+    if (meshRef.current) {
       meshRef.current.rotation.x = Math.sin(clock.elapsedTime * 0.2);
       meshRef.current.rotation.y = Math.sin(clock.elapsedTime * 0.5);
       meshRef.current.rotation.z = Math.sin(clock.elapsedTime);


### PR DESCRIPTION
Currently this crashes before getting to the baked lightmap with the following error:

```
TypeError
Cannot read property 'rotation' of null
Object.eval [as current]
/src/stories/Spinner.tsx:9:24
   6 | const meshRef = useResource<THREE.Mesh>();
   7 | 
   8 | useFrame(({ clock }) => {
>  9 |   if (meshRef.current.rotation.isEuler) {
     |                      ^
  10 |     meshRef.current.rotation.x = Math.sin(clock.elapsedTime * 0.2);
  11 |     meshRef.current.rotation.y = Math.sin(clock.elapsedTime * 0.5);
  12 |     meshRef.current.rotation.z = Math.sin(clock.elapsedTime);
```

With this small change, the demo runs and looks great.
